### PR TITLE
fix(repo-rules): add backup branches to blacklist

### DIFF
--- a/repo-rules.json
+++ b/repo-rules.json
@@ -19,7 +19,9 @@
         ],
         "blacklistedHeadBranchNames": [
           "master",
-          "staging"
+          "staging",
+          "backup/master",
+          "backup/staging"
         ]
       },
       "allowedBranchNames": [


### PR DESCRIPTION
This change adds 'backup/staging' and 'backup/master' branches to the head branches of repo rules for blacklist